### PR TITLE
simplify regex for user comment scraping

### DIFF
--- a/uk/ac/sanger/artemis/io/GFFStreamFeature.java
+++ b/uk/ac/sanger/artemis/io/GFFStreamFeature.java
@@ -906,7 +906,7 @@ public class GFFStreamFeature extends SimpleDocumentFeature implements
         Set<String> set = new HashSet<String>();
         if (values != null && values.size() > 0) {
           for (int value_index = 0; value_index < values.size(); ++value_index) {
-            String regex = "tritryp_uc[:=]\"?([^\";]+)";
+            String regex = "tritryp_uc[:=]\"?([a-zA-Z0-9]+)";
             Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
             Matcher matcher = pattern.matcher(values.elementAt(value_index));
             while (matcher.find()) {


### PR DESCRIPTION
Due to the variety of different specifications of usercomment IDs in the annotation history, a more stringent, simpler regex to capture them makes sense.
