### PR TITLE
extend escaping in qualifier values

### DIFF
--- a/uk/ac/sanger/artemis/io/StreamQualifier.java
+++ b/uk/ac/sanger/artemis/io/StreamQualifier.java
@@ -106,10 +106,14 @@ class StreamQualifier {
         buffer.append ('/');
         buffer.append (qualifier.getName ());
         if (values.elementAt (i) != null) {
+          /* Escape double quotes */
+          String processedValue = (String)values.elementAt (i).replaceAll("(^|[^\"])\"([^\"]|$)","$1\"\"$2");
+          /* Mask line breaks in entries (e.g. notes/history) */
+          processedValue = processedValue.replaceAll("\n", " ");
           buffer.append ('=');
-          buffer.append (quotedValue (qualifier_info,
-                                      qualifier.getName (),
-                                      (String)values.elementAt (i).replaceAll("(^|[^\"])\"([^\"]|$)","$1\"\"$2")));
+          buffer.append (quotedValue(qualifier_info,
+                                      qualifier.getName(),
+                                      processedValue));
         }
       }
 
@@ -140,10 +144,14 @@ class StreamQualifier {
         buffer.append ('/');
         buffer.append (qualifier.getName ());
         if (values.elementAt (i) != null) {
+          /* Escape double quotes */
+          String processedValue = (String)values.elementAt (i).replaceAll("(^|[^\"])\"([^\"]|$)","$1\"\"$2");
+          /* Mask line breaks in entries (e.g. notes/history) */
+          processedValue = processedValue.replaceAll("\n", " ");
           buffer.append ('=');
           buffer.append (quotedValue (qualifier_info,
                                       qualifier.getName (),
-                                      (String)values.elementAt (i).replaceAll("(^|[^\"])\"([^\"]|$)","$1\"\"$2")));
+                                      processedValue));
         }
         return_vector.add (buffer.toString ());
       }


### PR DESCRIPTION
Artemis breaks some EMBL output by not escaping double quotes and newlines in qualifier values, leading to invalid files which cannot be opened again by Artemis. This PR adds additional code, escaping them according to the EMBL spec as far as possible.
