### PR TITLE
Added uORF, sORF and tnaORF as extra keys

### DIFF
--- a/etc/key_mapping
+++ b/etc/key_mapping
@@ -24,3 +24,6 @@ modified_amino_acid_feature                misc_feature    note=modified_amino_a
 snRNA                                      ncRNA           ncRNA_class=snRNA
 snoRNA                                     ncRNA           ncRNA_class=snoRNA
 nucleotide_match                           misc_feature    note=nucleotide_match
+uORF                                       misc_feature    note=uORF
+sORF                                       misc_feature    note=sORF
+tnaORF                                     misc_feature    note=tnaORF

--- a/etc/options
+++ b/etc/options
@@ -423,7 +423,7 @@ extra_keys = \
     TMM signalP
 
 # this list is added to the keys from the feature_keys_gff file
-extra_keys_gff = CDS spliced_leader_RNA sequence_variant fasta_record
+extra_keys_gff = CDS uORF sORF tnaORF spliced_leader_RNA sequence_variant fasta_record
 
 # Names of qualifiers to search when attempting to find the primary or display
 # name of a gene.  These qualifiers names are searched in order when looking


### PR DESCRIPTION
Added uORF, sORF and tnaORF to the list of keys that can be dumped in the gffs (etc/option) and embl (etc/key_mapping). 
