### PR TITLE
add support for eupathdb_uc user comment attributes

### DIFF
--- a/etc/versions
+++ b/etc/versions
@@ -1,4 +1,4 @@
-Artemis Release 16.0.14
-ACT Release 13.0.14
+Artemis Release 16.0.15
+ACT Release 13.0.15
 DNAPlotter Release 1.11
 BamView 1.2.13

--- a/uk/ac/sanger/artemis/io/GFFStreamFeature.java
+++ b/uk/ac/sanger/artemis/io/GFFStreamFeature.java
@@ -906,7 +906,7 @@ public class GFFStreamFeature extends SimpleDocumentFeature implements
         Set<String> set = new HashSet<String>();
         if (values != null && values.size() > 0) {
           for (int value_index = 0; value_index < values.size(); ++value_index) {
-            String regex = "tritryp_uc[:=]\"?([a-zA-Z0-9]+)";
+            String regex = "eupathdb_uc[:=]\"?([a-zA-Z0-9]+)";
             Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
             Matcher matcher = pattern.matcher(values.elementAt(value_index));
             while (matcher.find()) {
@@ -949,8 +949,8 @@ public class GFFStreamFeature extends SimpleDocumentFeature implements
 
     // also put TriTryp UC numbers into separate attribute
     abuf.setClone("history", "tritryp_uc");
-    abuf.setAggregator("tritryp_uc", ucProc);
-    abuf.setGlue("tritryp_uc", ",");
+    abuf.setAggregator("eupathdb_uc", ucProc);
+    abuf.setGlue("eupathdb_uc", ",");
 
     // class
     abuf.setAggregator("class", classProc);


### PR DESCRIPTION
This PR updates Artemis to include the new `eupathdb_uc` attributes in the GFF3 output. This attribute had been introduced to Chado a while ago to unify the `plasmodb_uc` and `tritrypdb_uc` history tags and their variants.