### PR TITLE
actually clone the history attribute

### DIFF
--- a/uk/ac/sanger/artemis/io/GFFStreamFeature.java
+++ b/uk/ac/sanger/artemis/io/GFFStreamFeature.java
@@ -947,8 +947,8 @@ public class GFFStreamFeature extends SimpleDocumentFeature implements
     abuf.setAggregator("Ontology_term", goProc);
     abuf.setGlue("Ontology_term", ",");
 
-    // also put TriTryp UC numbers into separate attribute
-    abuf.setClone("history", "tritryp_uc");
+    // also put EuPathDB UC numbers into separate attribute
+    abuf.setClone("history", "eupathdb_uc");
     abuf.setAggregator("eupathdb_uc", ucProc);
     abuf.setGlue("eupathdb_uc", ",");
 


### PR DESCRIPTION
This PR fixes a bug where the handling of the `eupathdb_uc` attribute was changed but not in all required places, leading to a misnamed and unprocessed attribute in the output.