### PR TITLE
override abstract method close() in CRAMReferenceSequenceFile

### DIFF
--- a/uk/ac/sanger/artemis/components/alignment/CRAMReferenceSequenceFile.java
+++ b/uk/ac/sanger/artemis/components/alignment/CRAMReferenceSequenceFile.java
@@ -107,5 +107,8 @@ import uk.ac.sanger.artemis.util.OutOfRangeException;
     public void reset()
     {
     }
-    
+
+    public void close()
+    {
+    }
   }


### PR DESCRIPTION
Building from source (and using pre-installed dependencies) without this patch resulted in the following error:
artemis-16.0.0+dfsg/uk/ac/sanger/artemis/components/alignment/CRAMReferenceSequenceFile.java:35:
error: CRAMReferenceSequenceFile is not abstract and does not override abstract method close() in ReferenceSequenceFile

