### PR TITLE
switch to older EMBOSS version

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -5,9 +5,9 @@ set -e
 
 start_dir=$(pwd)
 
-EMBOSS_VERSION="6.6.0"
+EMBOSS_VERSION="6.5.7"
 
-EMBOSS_DOWNLOAD_URL="ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-${EMBOSS_VERSION}.tar.gz"
+EMBOSS_DOWNLOAD_URL="ftp://emboss.open-bio.org/pub/EMBOSS/old/6.5.0/EMBOSS-${EMBOSS_VERSION}.tar.gz"
 
 # Make an install location
 if [ ! -d "${HOME}/dependencies" ]; then


### PR DESCRIPTION
Artemis uses EMBOSS in tests. Unfortunately the version downloaded and built by `install_dependencies.sh` was completely pulled from their FTP server, making the tests fail.
This PR changes the version to be installed to be an older one, enabling the Artemis tests again.