### PR TITLE
fix method name clash for List.sort() in Java 8

### DIFF
--- a/uk/ac/sanger/artemis/AlignMatchVector.java
+++ b/uk/ac/sanger/artemis/AlignMatchVector.java
@@ -3,19 +3,19 @@
  * created: Sat Jun 17 2000
  *
  * This file is part of Artemis
- * 
+ *
  * Copyright (C) 2000,2001  Genome Research Limited
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
@@ -51,7 +51,7 @@ public class AlignMatchVector {
   public void addElement (AlignMatch item) {
     vector.add (item);
   }
-  
+
   /**
    *  Appends the given AlignMatch object to the vector if and only if it
    *  isn't already in the vector.  (same as addElement ()).
@@ -59,7 +59,7 @@ public class AlignMatchVector {
   public void add (AlignMatch item) {
     addElement (item);
   }
-  
+
   /**
    *  Performs the same function as Vector.elementAt ()
    **/
@@ -101,13 +101,13 @@ public class AlignMatchVector {
   public int size () {
     return vector.size ();
   }
-  
+
   /**
    *  Sort this vector.
    *  @param cmp The returned vector will be sorted with this Comparator.
    **/
   public void sort (final Comparator cmp) {
-    vector = vector.sort (cmp);
+    vector = vector.mysort (cmp);
   }
 
   /**

--- a/uk/ac/sanger/artemis/FeatureVector.java
+++ b/uk/ac/sanger/artemis/FeatureVector.java
@@ -154,7 +154,7 @@ public class FeatureVector {
   public FeatureVector sort (final Comparator cmp) {
     final FeatureVector return_vector = (FeatureVector) clone ();
 
-    return_vector.vector = return_vector.vector.sort (cmp);
+    return_vector.vector = return_vector.vector.mysort (cmp);
 
     return return_vector;
   }

--- a/uk/ac/sanger/artemis/io/KeyVector.java
+++ b/uk/ac/sanger/artemis/io/KeyVector.java
@@ -3,19 +3,19 @@
  * created: Fri Apr 16 1999
  *
  * This file is part of Artemis
- * 
+ *
  * Copyright (C) 1999  Genome Research Limited
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
@@ -39,13 +39,13 @@ public class KeyVector extends FastVector
 
   public KeyVector ()
   {
-    super();  
+    super();
   }
-  
+
   /**
    *  Create a new vector which contains only the given Key.
    **/
-  public KeyVector (final Key new_key) 
+  public KeyVector (final Key new_key)
   {
     super();
     add (new_key);
@@ -54,7 +54,7 @@ public class KeyVector extends FastVector
   /**
    *  Return a new copy of this object.
    **/
-  public KeyVector copy () 
+  public KeyVector copy ()
   {
     final KeyVector new_key_vector = (KeyVector)clone();
 
@@ -65,21 +65,21 @@ public class KeyVector extends FastVector
    * Sorts the elements of the vector using a simple O(n^2) selection
    * sort.
    */
-  public void sort() 
+  public void mysort()
   {
     int smallest;
 
-    for (int i = 0; i < size (); ++i) 
+    for (int i = 0; i < size (); ++i)
     {
       //find smallest remaining element
       smallest = i;
-      for(int j = i + 1 ; j < size () ; ++j) 
+      for(int j = i + 1 ; j < size () ; ++j)
       {
-        if(((Key)get(j)).compareTo( (Key)get(smallest)) < 0) 
+        if(((Key)get(j)).compareTo( (Key)get(smallest)) < 0)
           smallest = j;
       }
       //exchange smallest and i
-      if (smallest != i) 
+      if (smallest != i)
       {
         final Key tmp = (Key)get(i);
         setElementAt (get(smallest), i);

--- a/uk/ac/sanger/artemis/io/SimpleEntryInformation.java
+++ b/uk/ac/sanger/artemis/io/SimpleEntryInformation.java
@@ -175,7 +175,7 @@ public class SimpleEntryInformation
       return null;
     }
 
-    return_vector.sort ();
+    return_vector.mysort ();
     return return_vector;
   }
 
@@ -187,11 +187,11 @@ public class SimpleEntryInformation
 
     if (isValidKey (misc_feature_key))
       return misc_feature_key;
-    
+
     misc_feature_key = new Key ("region");
     if (isValidKey (misc_feature_key))
       return misc_feature_key;
-   
+
     return (Key)getValidKeys ().get (0);
   }
 
@@ -397,7 +397,7 @@ public class SimpleEntryInformation
       return getQualifierInfoHash ().copy ();
     }
   }
-    
+
   /**
    *  Fix this EntryInformation so that the given exception won't happen
    *  again.

--- a/uk/ac/sanger/artemis/util/FastVector.java
+++ b/uk/ac/sanger/artemis/util/FastVector.java
@@ -3,19 +3,19 @@
  * created: Sun Feb 20 2000
  *
  * This file is part of Artemis
- * 
+ *
  * Copyright (C) 2000  Genome Research Limited
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
@@ -43,9 +43,9 @@ public class FastVector extends ArrayList
   /**
    *  Performs the same function as Vector.addElement()
    */
-  public boolean add(Object object) 
+  public boolean add(Object object)
   {
-    if(object == null) 
+    if(object == null)
       throw new Error("internal error - adding a null object");
     else if(contains(object))
       throw new Error("internal error - object added a second time");
@@ -56,24 +56,24 @@ public class FastVector extends ArrayList
   /**
    *  Performs the same function as Vector.lastElement()
    **/
-  public Object lastElement() 
+  public Object lastElement()
   {
     return (Object)get(size() - 1);
   }
-  
+
   /**
    *  Insert an Object after another.
    *  @param old_object The new_object will be inserted after this object
    *    or at the start if old_object isn't in the vector.
    *  @param new_object The new object to insert.
    **/
-  public void insertElementAfter(Object old_object, Object new_object) 
+  public void insertElementAfter(Object old_object, Object new_object)
   {
     final int old_object_index = indexOf(old_object);
 
-    if(old_object_index == -1) 
+    if(old_object_index == -1)
       add(0, new_object);
-    else 
+    else
       add(old_object_index + 1, new_object);
   }
 
@@ -81,7 +81,7 @@ public class FastVector extends ArrayList
    *  Replace the Object at the given index. (Performs the same function as
    *  Vector.elementAt())
    **/
-  public void setElementAt(final Object object, final int index) 
+  public void setElementAt(final Object object, final int index)
   {
     remove(index);
     add(index, object);
@@ -91,7 +91,7 @@ public class FastVector extends ArrayList
    *  Return a sorted copy of this vector.
    *  @param cmp The returned vector will be sorted with this Comparator.
    **/
-  public FastVector sort(final Comparator cmp) 
+  public FastVector mysort(final Comparator cmp)
   {
     final FastVector return_vector = (FastVector)clone();
     Collections.sort(return_vector, cmp);

--- a/uk/ac/sanger/artemis/util/StringVector.java
+++ b/uk/ac/sanger/artemis/util/StringVector.java
@@ -51,11 +51,11 @@ public class StringVector extends Vector<String>
   /**
    *  Create a new vector which contains the given Strings.
    **/
-  public StringVector(final String[] new_strings) 
+  public StringVector(final String[] new_strings)
   {
     super(new_strings.length);
     int len = new_strings.length;
-    for(int i = 0; i < len; ++i) 
+    for(int i = 0; i < len; ++i)
       add(new_strings[i]);
   }
 
@@ -68,7 +68,7 @@ public class StringVector extends Vector<String>
   /**
    *  Create a new vector which contains the given Strings.
    **/
-  public StringVector(final StringVector new_strings) 
+  public StringVector(final StringVector new_strings)
   {
     super(new_strings);
   }
@@ -76,7 +76,7 @@ public class StringVector extends Vector<String>
   /**
    *  Call add() on each of the String objects in the given StringVector.
    **/
-  public void add(final StringVector new_strings) 
+  public void add(final StringVector new_strings)
   {
     for (int i = 0; i < new_strings.size(); ++i)
       add (new_strings.elementAt(i));
@@ -87,19 +87,19 @@ public class StringVector extends Vector<String>
    *  package.
    */
   public void sort()
-  { 
+  {
     final Comparator<String> comparator = new Comparator<String>()
     {
-      public int compare(String fst, String snd) 
+      public int compare(String fst, String snd)
       {
-        if(fst == null) 
+        if(fst == null)
         {
           if(snd == null)
             return 0;
           else
             return -1;
-        } 
-        else 
+        }
+        else
         {
           if(snd == null)
             return 1;
@@ -114,7 +114,7 @@ public class StringVector extends Vector<String>
   /**
    *  Return a new copy of this object.
    **/
-  public StringVector copy() 
+  public StringVector copy()
   {
     return new StringVector(this);
   }
@@ -132,7 +132,7 @@ public class StringVector extends Vector<String>
    **/
   public static StringVector getStrings(final String argument,
                                         final String delim,
-                                        final boolean keep_zero_char_toks) 
+                                        final boolean keep_zero_char_toks)
   {
     final StringVector strVector = new StringVector();
 
@@ -153,23 +153,23 @@ public class StringVector extends Vector<String>
 
       if(idx2 < 0)
         idx2 = argLen;
- 
+
       tok = argument.substring(idx1,idx2);
       idx1 = idx2+1;
 
       if(tok.length() == 1 &&
-          delim.indexOf(tok.charAt(0)) != -1) 
+          delim.indexOf(tok.charAt(0)) != -1)
       {
         // ignore the split characters
         if(keep_zero_char_toks &&
            (lastTok == null ||
             lastTok != null && lastTok.length () == 1 &&
-            delim.indexOf (lastTok) != -1)) 
+            delim.indexOf (lastTok) != -1))
         {
           // add a space because of two split_characters in a row
           strVector.add("");
         }
-      } 
+      }
       else
         strVector.add(tok);
 
@@ -186,7 +186,7 @@ public class StringVector extends Vector<String>
    *  vector will be zero length.
    **/
   public static StringVector getStrings(final String argument,
-                                        final String split_characters) 
+                                        final String split_characters)
   {
     return getStrings(argument, split_characters, false);
   }
@@ -198,7 +198,7 @@ public class StringVector extends Vector<String>
    *  String is zero length or it consists only of whitespace, the return
    *  vector will be zero length.
    **/
-  public static StringVector getStrings(final String argument) 
+  public static StringVector getStrings(final String argument)
   {
     return getStrings(argument, " ", false);
   }


### PR DESCRIPTION
This PR renames some sorting methods in FastVector derived classes to no longer clash with Java 8's new `List.sort()` standard library method. Thanks to Emmanuel Bourg for fixing advice.