### PR TITLE
Addition to PR297: Changed exit codes for art and dnaplotter help

### DIFF
--- a/art
+++ b/art
@@ -41,7 +41,7 @@ usage () {
     echo "        http://www.sanger.ac.uk/science/tools/artemis"
     echo   
     
-    exit 1
+    exit 0
 }
 
 add_proxy_properties() {

--- a/dnaplotter
+++ b/dnaplotter
@@ -22,7 +22,7 @@ usage () {
     echo "        http://www.sanger.ac.uk/science/tools/dnaplotter/"
     echo   
     
-    exit 1
+    exit 0
 }
 
 add_proxy_properties() {


### PR DESCRIPTION
Changed exit codes to 0 for art and dnaplotter help, to be consistent with PR #297 and issue #296.