### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,10 @@ Artemis is written in Java, and is available for UNIX, Macintosh and Windows sys
 					<showWarnings>true</showWarnings>
 					<!--  We use the release option for Java 9+ -->
         			<release>${java.compatibility.major.version}</release>
+							<fork>true</fork>
+							<useIncrementalCompilation>true</useIncrementalCompilation>
+
+
     			</configuration>
 			</plugin>
 					
@@ -1255,6 +1259,10 @@ Artemis is written in Java, and is available for UNIX, Macintosh and Windows sys
 							<verbose>false</verbose>
 		        				<source>1.8</source>
 								<target>1.8</target>
+							<fork>true</fork>
+							<useIncrementalCompilation>true</useIncrementalCompilation>
+
+
 		    				</configuration>
 					</plugin>
 					


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

Maven can recompile only the classes that were affected by a change. This feature is the default. We can activate it by setting `<useIncrementalCompilation>true</useIncrementalCompilation>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
