### PR TITLE
typo fix for MAPQ filter pane

### DIFF
--- a/src/main/java/uk/ac/sanger/artemis/components/alignment/SAMRecordFilter.java
+++ b/src/main/java/uk/ac/sanger/artemis/components/alignment/SAMRecordFilter.java
@@ -46,7 +46,7 @@ class SAMRecordFilter extends JFrame
     c.gridy = nrows++;
     
     // MAPQ
-    pane.add(new JLabel(" By Mappying Quality (mapq) cut-off:"),c);
+    pane.add(new JLabel(" By Mapping Quality (mapq) cut-off:"),c);
     
     c.gridy = nrows++;
     c.gridwidth = 1;


### PR DESCRIPTION
Just a simple typo fix in a string.